### PR TITLE
Update metro.config.js typo

### DIFF
--- a/apps/rnative/metro.config.js
+++ b/apps/rnative/metro.config.js
@@ -73,7 +73,7 @@ config.watchFolders = [
 /**
  * Make sure to include app & package node_modules
  */
-config.resolver.nodeModulesPath = [
+config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),
 ];


### PR DESCRIPTION
Add the 's' of nodeModulesPath.
nodeModulesPath -> nodeModulesPaths

https://facebook.github.io/metro/docs/configuration/#nodemodulespaths

I lost a bit of time about this one, not understanding why it wasn't working.